### PR TITLE
Validate EAR argument signature when parsing commands

### DIFF
--- a/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
+++ b/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
@@ -1,7 +1,7 @@
 package eflang.ear.compiler;
 
 import eflang.ear.core.Command;
-import eflang.ear.core.InstructionParser;
+import eflang.ear.core.CommandParser;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,6 +13,6 @@ public class EARParser {
 
     public static List<Command> parse(String earCode) {
         List<String> lines = Arrays.asList(earCode.split("(\\r?\\n)+"));
-        return lines.stream().map(InstructionParser::parseLine).collect(Collectors.toList());
+        return lines.stream().map(CommandParser::parseLine).collect(Collectors.toList());
     }
 }

--- a/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
+++ b/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
@@ -13,6 +13,6 @@ public class EARParser {
 
     public static List<Command> parse(String earCode) {
         List<String> lines = Arrays.asList(earCode.split("(\\r?\\n)+"));
-        return lines.stream().map(CommandParser::parseLine).collect(Collectors.toList());
+        return lines.stream().map(CommandParser::parseCommand).collect(Collectors.toList());
     }
 }

--- a/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
+++ b/ear-compiler/src/main/java/eflang/ear/compiler/EARParser.java
@@ -13,6 +13,7 @@ public class EARParser {
 
     public static List<Command> parse(String earCode) {
         List<String> lines = Arrays.asList(earCode.split("(\\r?\\n)+"));
-        return lines.stream().map(CommandParser::parseCommand).collect(Collectors.toList());
+        CommandParser parser = CommandParser.defaultCommandParser();
+        return lines.stream().map(parser::parseCommand).collect(Collectors.toList());
     }
 }

--- a/ear-core/src/main/java/eflang/ear/core/Argument.java
+++ b/ear-core/src/main/java/eflang/ear/core/Argument.java
@@ -40,4 +40,23 @@ public class Argument {
             return String.format("%d", value);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof Argument)) {
+            return false;
+        }
+
+        Argument that = (Argument) o;
+        return (this.type == that.type) && (this.value == that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode() ^ Integer.hashCode(value);
+    }
 }

--- a/ear-core/src/main/java/eflang/ear/core/Argument.java
+++ b/ear-core/src/main/java/eflang/ear/core/Argument.java
@@ -28,4 +28,16 @@ public class Argument {
     public static Argument cell(int value) {
         return new Argument(Type.CELL, value);
     }
+
+    public static ArgumentValidator validator() {
+        return new ArgumentValidator();
+    }
+
+    public String toString() {
+        if (type == Type.CELL) {
+            return String.format("@%d", value);
+        } else {
+            return String.format("%d", value);
+        }
+    }
 }

--- a/ear-core/src/main/java/eflang/ear/core/ArgumentValidator.java
+++ b/ear-core/src/main/java/eflang/ear/core/ArgumentValidator.java
@@ -1,0 +1,109 @@
+package eflang.ear.core;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArgumentValidator {
+    List<ArgSpec> argSpecs;
+
+    ArgumentValidator() {
+        this.argSpecs = new ArrayList<>();
+    }
+
+    public void validate(List<Argument> args) throws EARInvalidSignatureException {
+        // Copy the args so we don't destroy the input list.
+        args = Lists.newArrayList(args);
+
+        int manyIndex = Iterables.indexOf(argSpecs, spec -> spec.arity == Arity.MANY);
+        if (manyIndex == -1) {
+            // No MANY, just simple validate.
+            simpleValidate(argSpecs, args);
+            return;
+        }
+
+        // Check we have enough args for this to even make sense.
+        if (args.size() <= manyIndex) {
+            throw new EARInvalidSignatureException("Too few args");
+        }
+
+        // Validate stuff before the MANY.
+        simpleValidate(argSpecs.subList(0, manyIndex), args.subList(0, manyIndex));
+
+        // Validate stuff after the MANY if any.
+        List<ArgSpec> afterMany = argSpecs.subList(manyIndex + 1, argSpecs.size());
+        simpleValidate(afterMany, args.subList(args.size() - afterMany.size(), args.size()));
+
+        // Validate the MANY.
+        ArgSpec manySpec = argSpecs.get(manyIndex);
+        List<Argument> manyArgs = args.subList(manyIndex, args.size() - afterMany.size());
+        if (!manyArgs.stream().allMatch(arg -> manySpec.matchType(arg.getType()))) {
+            throw new EARInvalidSignatureException("Wrong argument types");
+        }
+    }
+
+    private void simpleValidate(List<ArgSpec> specs, List<Argument> args) throws EARInvalidSignatureException {
+        if (specs.stream().anyMatch(spec -> spec.arity == Arity.MANY)) {
+            throw new RuntimeException("Can't pass MANY spec to simpleValidate");
+        }
+
+        if (specs.size() != args.size()) {
+            throw new EARInvalidSignatureException("Wrong number of args");
+        }
+
+        if (!Streams.zip(specs.stream(), args.stream(), (spec, arg) -> spec.matchType(arg.getType()))
+                .allMatch(x -> x)) {
+            throw new EARInvalidSignatureException("Wrong argument types");
+        }
+    }
+
+    public ArgumentValidator one(Type type) {
+        argSpecs.add(new ArgSpec(type, Arity.ONE));
+        return this;
+    }
+
+    public ArgumentValidator many(Type type) {
+        if (argSpecs.stream().anyMatch(spec -> spec.arity == Arity.MANY)) {
+            throw new RuntimeException("Argument list may only contain one varargs");
+        }
+        argSpecs.add(new ArgSpec(type, Arity.MANY));
+        return this;
+    }
+
+    private class ArgSpec {
+        Type type;
+        Arity arity;
+
+        ArgSpec(Type type, Arity arity) {
+            this.type = type;
+            this.arity = arity;
+        }
+
+        boolean matchType(Argument.Type argType) {
+            switch (type) {
+                case EITHER:
+                    return true;
+                case CELL:
+                    return argType == Argument.Type.CELL;
+                case CONSTANT:
+                    return argType == Argument.Type.CONSTANT;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    private enum Arity {
+        ONE,
+        MANY
+    }
+
+    public enum Type {
+        CELL,
+        CONSTANT,
+        EITHER
+    }
+}

--- a/ear-core/src/main/java/eflang/ear/core/Command.java
+++ b/ear-core/src/main/java/eflang/ear/core/Command.java
@@ -3,6 +3,7 @@ package eflang.ear.core;
 import eflang.ear.operation.Operation;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Command {
     private Operation operation;
@@ -17,7 +18,23 @@ public class Command {
         return operation.compile(arguments);
     }
 
+    public void validate() throws EARException {
+        operation.validateArgs(arguments);
+    }
+
     public static Command of(Operation operation, List<Argument> arguments) {
-        return new Command(operation, arguments);
+        Command cmd = new Command(operation, arguments);
+        try {
+            cmd.validate();
+        } catch (EARException e) {
+            throw new RuntimeException("Invalid command: " + cmd, e);
+        }
+        return cmd;
+    }
+
+    public String toString() {
+        String argString = String.join(" ",
+                arguments.stream().map(Argument::toString).collect(Collectors.toList()));
+        return String.format("%s %s", operation, argString);
     }
 }

--- a/ear-core/src/main/java/eflang/ear/core/Command.java
+++ b/ear-core/src/main/java/eflang/ear/core/Command.java
@@ -37,4 +37,23 @@ public class Command {
                 arguments.stream().map(Argument::toString).collect(Collectors.toList()));
         return String.format("%s %s", operation, argString);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof Command)) {
+            return false;
+        }
+
+        Command that = (Command) o;
+        return (this.operation.getClass() == that.operation.getClass()) && (this.arguments.equals(that.arguments));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.operation.getClass().hashCode() ^ this.arguments.hashCode();
+    }
 }

--- a/ear-core/src/main/java/eflang/ear/core/CommandParser.java
+++ b/ear-core/src/main/java/eflang/ear/core/CommandParser.java
@@ -7,9 +7,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class InstructionParser {
+public class CommandParser {
 
-    private InstructionParser() {}
+    private CommandParser() {}
 
     public static Command parseLine(String line) {
         line = line.trim();
@@ -19,7 +19,7 @@ public class InstructionParser {
 
         List<String> tokens = Arrays.asList(line.split(" +"));
         List<Argument> args = tokens.subList(1, tokens.size()).stream()
-                .map(InstructionParser::parseArg)
+                .map(CommandParser::parseArg)
                 .collect(Collectors.toList());
 
         return Command.of(lookupOperation(tokens.get(0)), args);

--- a/ear-core/src/main/java/eflang/ear/core/CommandParser.java
+++ b/ear-core/src/main/java/eflang/ear/core/CommandParser.java
@@ -11,7 +11,7 @@ public class CommandParser {
 
     private CommandParser() {}
 
-    public static Command parseLine(String line) {
+    public static Command parseCommand(String line) {
         line = line.trim();
         if ((line.equals("")) || (isComment(line))) {
             return Command.of(new Noop(), Collections.emptyList());

--- a/ear-core/src/main/java/eflang/ear/operation/Add.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Add.java
@@ -1,6 +1,8 @@
 package eflang.ear.operation;
 
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -51,5 +53,17 @@ public class Add implements Operation {
         }
 
         return instructions;
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .many(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "ADD";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Add.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Add.java
@@ -13,8 +13,6 @@ import java.util.stream.Stream;
 public class Add implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() > 1;
-
         List<Integer> outputCells = args.subList(1, args.size()).stream()
                 .map(Argument::getValue)
                 .collect(Collectors.toList());

--- a/ear-core/src/main/java/eflang/ear/operation/Copy.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Copy.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -45,5 +47,18 @@ public class Copy implements Operation {
             default:
                 throw new RuntimeException("Unknown arg type");
         }
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .many(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "COPY";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Copy.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Copy.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 public class Copy implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() >= 3;
-
         switch (args.get(0).getType()) {
             case CONSTANT:
                 // If passed a constant arg, just use MOV since it's faster and has the same result.

--- a/ear-core/src/main/java/eflang/ear/operation/Divide.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Divide.java
@@ -12,8 +12,6 @@ import java.util.List;
 public class Divide implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 9;
-
         Argument numerator = args.get(0);
         Argument denominator = args.get(1);
         Argument tgt = args.get(2);

--- a/ear-core/src/main/java/eflang/ear/operation/Divide.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Divide.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -138,5 +140,24 @@ public class Divide implements Operation {
                 Argument.constant(numerator / denominator),
                 Argument.constant(tgt)
         ));
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .one(ArgumentValidator.Type.EITHER)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "DIV";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/EndWhile.java
+++ b/ear-core/src/main/java/eflang/ear/operation/EndWhile.java
@@ -2,6 +2,7 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.List;
@@ -14,5 +15,15 @@ public class EndWhile implements Operation {
         return ImmutableList.of(
                 Instruction.endLoop()
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .validate(args);
+    }
+
+    public String toString() {
+        return "ENDWHILE";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/EndWhile.java
+++ b/ear-core/src/main/java/eflang/ear/operation/EndWhile.java
@@ -10,8 +10,6 @@ import java.util.List;
 public class EndWhile implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 0;
-
         return ImmutableList.of(
                 Instruction.endLoop()
         );

--- a/ear-core/src/main/java/eflang/ear/operation/Goto.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Goto.java
@@ -12,7 +12,6 @@ public class Goto implements Operation {
 
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 1;
         return ImmutableList.of(
                 Instruction.goTo(args.get(0).getValue())
         );

--- a/ear-core/src/main/java/eflang/ear/operation/Goto.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Goto.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.List;
@@ -14,5 +16,16 @@ public class Goto implements Operation {
         return ImmutableList.of(
                 Instruction.goTo(args.get(0).getValue())
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "GOTO";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Input.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Input.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.List;
@@ -17,5 +19,16 @@ public class Input implements Operation {
                 Instruction.ensureSad(),
                 Instruction.rest()
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "IN";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Input.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Input.java
@@ -11,7 +11,6 @@ import java.util.List;
 public class Input implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 1;
         int cell = args.get(0).getValue();
 
         return ImmutableList.of(

--- a/ear-core/src/main/java/eflang/ear/operation/Move.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Move.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -28,5 +30,17 @@ public class Move implements Operation {
         instructions.addAll((new Add()).compile(args));
 
         return instructions;
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .many(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "MOV";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Move.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Move.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 public class Move implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() > 1;
-
         List<Instruction> instructions = new ArrayList<>();
 
         List<Integer> outputCells = args.subList(1, args.size()).stream()

--- a/ear-core/src/main/java/eflang/ear/operation/Multiply.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Multiply.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -95,5 +97,19 @@ public class Multiply implements Operation {
         instructions.add(Instruction.endLoop());
 
         return instructions;
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .one(ArgumentValidator.Type.EITHER)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "MUL";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Multiply.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Multiply.java
@@ -12,8 +12,6 @@ import java.util.List;
 public class Multiply implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 4;
-
         Argument a0 = args.get(0);
         Argument a1 = args.get(1);
         Argument tgt = args.get(2);

--- a/ear-core/src/main/java/eflang/ear/operation/Noop.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Noop.java
@@ -1,6 +1,7 @@
 package eflang.ear.operation;
 
 import eflang.ear.core.Argument;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.Collections;
@@ -10,5 +11,15 @@ public class Noop implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
         return Collections.emptyList();
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .validate(args);
+    }
+
+    public String toString() {
+        return "NOP";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Operation.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Operation.java
@@ -15,4 +15,5 @@ public interface Operation {
     }
 
     void validateArgs(List<Argument> args) throws EARException;
+
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Operation.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Operation.java
@@ -1,6 +1,7 @@
 package eflang.ear.operation;
 
 import eflang.ear.core.Argument;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.Arrays;
@@ -12,4 +13,6 @@ public interface Operation {
     default List<Instruction> compile(Argument... args) {
         return compile(Arrays.asList(args));
     }
+
+    void validateArgs(List<Argument> args) throws EARException;
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Output.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Output.java
@@ -11,7 +11,6 @@ import java.util.List;
 public class Output implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 1;
         int cell = args.get(0).getValue();
 
         return ImmutableList.of(

--- a/ear-core/src/main/java/eflang/ear/operation/Output.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Output.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.List;
@@ -17,5 +19,16 @@ public class Output implements Operation {
                 Instruction.ensureHappy(),
                 Instruction.rest()
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "OUT";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Subtract.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Subtract.java
@@ -1,6 +1,8 @@
 package eflang.ear.operation;
 
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.ArrayList;
@@ -51,5 +53,17 @@ public class Subtract implements Operation {
         }
 
         return instructions;
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.EITHER)
+                .many(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "SUB";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Subtract.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Subtract.java
@@ -13,8 +13,6 @@ import java.util.stream.Stream;
 public class Subtract implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() > 1;
-
         List<Integer> outputCells = args.subList(1, args.size()).stream()
                 .map(Argument::getValue)
                 .collect(Collectors.toList());

--- a/ear-core/src/main/java/eflang/ear/operation/While.java
+++ b/ear-core/src/main/java/eflang/ear/operation/While.java
@@ -8,7 +8,6 @@ import java.util.List;
 public class While implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 1;
         int cell = args.get(0).getValue();
 
         return ImmutableList.of(

--- a/ear-core/src/main/java/eflang/ear/operation/While.java
+++ b/ear-core/src/main/java/eflang/ear/operation/While.java
@@ -1,8 +1,7 @@
 package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
-import eflang.ear.core.Argument;
-import eflang.ear.core.Instruction;
+import eflang.ear.core.*;
 
 import java.util.List;
 
@@ -16,5 +15,16 @@ public class While implements Operation {
                 Instruction.goTo(cell),
                 Instruction.startLoop()
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "WHILE";
     }
 }

--- a/ear-core/src/main/java/eflang/ear/operation/Zero.java
+++ b/ear-core/src/main/java/eflang/ear/operation/Zero.java
@@ -2,6 +2,8 @@ package eflang.ear.operation;
 
 import com.google.common.collect.ImmutableList;
 import eflang.ear.core.Argument;
+import eflang.ear.core.ArgumentValidator;
+import eflang.ear.core.EARException;
 import eflang.ear.core.Instruction;
 
 import java.util.List;
@@ -9,7 +11,6 @@ import java.util.List;
 public class Zero implements Operation {
     @Override
     public List<Instruction> compile(List<Argument> args) {
-        assert args.size() == 1;
         int cell = args.get(0).getValue();
         return ImmutableList.of(
                 Instruction.goTo(cell),
@@ -18,5 +19,16 @@ public class Zero implements Operation {
                 Instruction.decrement(),
                 Instruction.endLoop()
         );
+    }
+
+    @Override
+    public void validateArgs(List<Argument> args) throws EARException {
+        Argument.validator()
+                .one(ArgumentValidator.Type.CONSTANT)
+                .validate(args);
+    }
+
+    public String toString() {
+        return "ZERO";
     }
 }

--- a/ear-core/src/test/java/eflang/ear/core/ArgumentValidatorTest.java
+++ b/ear-core/src/test/java/eflang/ear/core/ArgumentValidatorTest.java
@@ -1,0 +1,206 @@
+package eflang.ear.core;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ArgumentValidatorTest {
+    @Test
+    void testNoArgsSuccess() {
+        validates(Argument.validator(), ImmutableList.of());
+    }
+
+    @Test
+    void testNoArgsFailsWhenPassedAnyArgs() {
+        doesNotValidate(Argument.validator(), ImmutableList.of(Argument.constant(0)));
+    }
+
+    @Test
+    void testOneCellValidates() {
+        validates(Argument.validator().one(ArgumentValidator.Type.CELL), ImmutableList.of(Argument.cell(0)));
+    }
+
+    @Test
+    void testOneConstantValidates() {
+        validates(Argument.validator().one(ArgumentValidator.Type.CONSTANT), ImmutableList.of(Argument.constant(0)));
+    }
+
+    @Test
+    void testConstDoestNotValidateCell() {
+        doesNotValidate(Argument.validator().one(ArgumentValidator.Type.CONSTANT), ImmutableList.of(Argument.cell(0)));
+    }
+
+    @Test
+    void testCellDoesNotValidateConst() {
+        doesNotValidate(Argument.validator().one(ArgumentValidator.Type.CELL), ImmutableList.of(Argument.constant(0)));
+    }
+
+    @Test
+    void testEitherValidatesCell() {
+        validates(Argument.validator().one(ArgumentValidator.Type.EITHER), ImmutableList.of(Argument.cell(0)));
+    }
+
+    @Test
+    void testEitherValidatesConst() {
+        validates(Argument.validator().one(ArgumentValidator.Type.EITHER), ImmutableList.of(Argument.constant(0)));
+    }
+
+    @Test
+    void testCellDoesNotValidateEmpty() {
+        doesNotValidate(Argument.validator().one(ArgumentValidator.Type.CELL), ImmutableList.of());
+    }
+
+    @Test
+    void testConstDoesNotValidateEmpty() {
+        doesNotValidate(Argument.validator().one(ArgumentValidator.Type.CONSTANT), ImmutableList.of());
+    }
+
+    @Test
+    void testEitherDoesNotValidateEmpty() {
+        doesNotValidate(Argument.validator().one(ArgumentValidator.Type.EITHER), ImmutableList.of());
+    }
+
+    @Test
+    void testMixedWithSuccess() {
+        validates(
+                Argument.validator()
+                        .one(ArgumentValidator.Type.CELL)
+                        .one(ArgumentValidator.Type.CONSTANT)
+                        .one(ArgumentValidator.Type.CELL),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.constant(0),
+                        Argument.cell(0)
+                )
+        );
+    }
+
+    @Test
+    void testMixedWithTooFew() {
+        doesNotValidate(
+                Argument.validator()
+                        .one(ArgumentValidator.Type.CELL)
+                        .one(ArgumentValidator.Type.CONSTANT)
+                        .one(ArgumentValidator.Type.CELL),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.constant(0)
+                )
+        );
+    }
+
+    @Test
+    void testMixedWithTooMany() {
+        doesNotValidate(
+                Argument.validator()
+                        .one(ArgumentValidator.Type.CELL)
+                        .one(ArgumentValidator.Type.CONSTANT)
+                        .one(ArgumentValidator.Type.CELL),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.constant(0),
+                        Argument.cell(0),
+                        Argument.cell(0)
+                )
+        );
+    }
+
+    @Test
+    void testMixedWithWrongTypes() {
+        doesNotValidate(
+                Argument.validator()
+                        .one(ArgumentValidator.Type.CELL)
+                        .one(ArgumentValidator.Type.CONSTANT)
+                        .one(ArgumentValidator.Type.CELL),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.constant(0),
+                        Argument.constant(0)
+                )
+        );
+    }
+
+    @Test
+    void testManyDoesNotValidateNone() {
+        doesNotValidate(Argument.validator().many(ArgumentValidator.Type.CELL), ImmutableList.of());
+    }
+
+    @Test
+    void testManyValidatesOne() {
+        validates(Argument.validator().many(ArgumentValidator.Type.CELL), ImmutableList.of(Argument.cell(0)));
+    }
+
+    @Test
+    void testManyValidatesMany() {
+        validates(
+                Argument.validator().many(ArgumentValidator.Type.CELL),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.cell(1),
+                        Argument.cell(2)
+                )
+        );
+    }
+
+    @Test
+    void testOneThenMany() {
+        validates(
+                Argument.validator().one(ArgumentValidator.Type.CELL).many(ArgumentValidator.Type.CONSTANT),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.constant(1),
+                        Argument.constant(2),
+                        Argument.constant(3)
+                )
+        );
+    }
+
+    @Test
+    void testManyThenOne() {
+        validates(
+                Argument.validator().many(ArgumentValidator.Type.CELL).one(ArgumentValidator.Type.CONSTANT),
+                ImmutableList.of(
+                        Argument.cell(0),
+                        Argument.cell(1),
+                        Argument.cell(2),
+                        Argument.constant(3)
+                )
+        );
+    }
+
+    @Test
+    void testOneThenManyThenOne() {
+        validates(
+                Argument.validator()
+                        .one(ArgumentValidator.Type.CONSTANT)
+                        .many(ArgumentValidator.Type.CELL)
+                        .one(ArgumentValidator.Type.CONSTANT),
+                ImmutableList.of(
+                        Argument.constant(3),
+                        Argument.cell(0),
+                        Argument.cell(1),
+                        Argument.cell(2),
+                        Argument.constant(3)
+                )
+        );
+    }
+
+    private void validates(ArgumentValidator validator, List<Argument> args) {
+        try {
+            validator.validate(args);
+        } catch (EARInvalidSignatureException e) {
+            fail("Failed validation", e);
+        }
+    }
+
+    private void doesNotValidate(ArgumentValidator validator, List<Argument> args) {
+        try {
+            validator.validate(args);
+            fail("Should have failed validation");
+        } catch (EARInvalidSignatureException e) {
+        }
+    }
+}

--- a/ear-core/src/test/java/eflang/ear/core/CommandParserTest.java
+++ b/ear-core/src/test/java/eflang/ear/core/CommandParserTest.java
@@ -1,0 +1,98 @@
+package eflang.ear.core;
+
+import com.google.common.collect.ImmutableList;
+import eflang.ear.operation.Noop;
+import eflang.ear.operation.Operation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class CommandParserTest {
+
+    private static CommandParser parser = new CommandParser()
+            .registerOperation("TEST", TestOperation::new)
+            .registerOperation("NOARGS", ZeroArgsOperation::new);
+
+    @Test
+    void testParseEmptyAsNoop() {
+        parses("", Command.of(new Noop(), ImmutableList.of()));
+    }
+
+    @Test
+    void testFailToParseUnknownOperation() {
+        doesNotParse("SOMETHING");
+    }
+
+    @Test
+    void testParsesKnownCommand() {
+        parses("TEST 1 2 3", Command.of(
+                new TestOperation(),
+                ImmutableList.of(
+                        Argument.constant(1),
+                        Argument.constant(2),
+                        Argument.constant(3)
+                )
+        ));
+    }
+
+    @Test
+    void testParsesCellReferences() {
+        parses("TEST @1 2 @3", Command.of(
+                new TestOperation(),
+                ImmutableList.of(
+                        Argument.cell(1),
+                        Argument.constant(2),
+                        Argument.cell(3)
+                )
+        ));
+    }
+
+    @Test
+    void testChecksArgumentsAreValid() {
+        parses("NOARGS", Command.of(new ZeroArgsOperation(), ImmutableList.of()));
+        doesNotParse("NOARGS 1 2");
+    }
+
+    private void doesNotParse(String line) {
+        try {
+            parser.parseCommand(line);
+            fail("Should have failed to parse");
+        } catch (Exception e) {
+        }
+    }
+
+    private void parses(String line, Command cmd) {
+        assertEquals(cmd, parser.parseCommand(line));
+    }
+
+    private static class TestOperation implements Operation {
+
+        @Override
+        public List<Instruction> compile(List<Argument> args) {
+            return null;
+        }
+
+        @Override
+        public void validateArgs(List<Argument> args) throws EARException {
+
+        }
+    }
+
+    private static class ZeroArgsOperation implements Operation {
+
+        @Override
+        public List<Instruction> compile(List<Argument> args) {
+            return null;
+        }
+
+        @Override
+        public void validateArgs(List<Argument> args) throws EARException {
+            if (args.size() > 0) {
+                throw new EARInvalidOpcodeException("Always invalid");
+            }
+        }
+    }
+}

--- a/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
+++ b/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
@@ -21,8 +21,9 @@ public class EARJit {
     }
 
     public void run(String earCode) {
+        CommandParser parser = CommandParser.defaultCommandParser();
         List<Instruction> instructions = Arrays.asList(earCode.split("(\\r?\\n)+")).stream()
-                .map(CommandParser::parseCommand)
+                .map(parser::parseCommand)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
+++ b/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
@@ -22,7 +22,7 @@ public class EARJit {
 
     public void run(String earCode) {
         List<Instruction> instructions = Arrays.asList(earCode.split("(\\r?\\n)+")).stream()
-                .map(CommandParser::parseLine)
+                .map(CommandParser::parseCommand)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
+++ b/ear-jit/src/main/java/eflang/ear/jit/EARJit.java
@@ -4,7 +4,7 @@ import eflang.core.*;
 import eflang.ear.composer.Composer;
 import eflang.ear.core.Command;
 import eflang.ear.core.Instruction;
-import eflang.ear.core.InstructionParser;
+import eflang.ear.core.CommandParser;
 import eflang.ear.core.StatefulInstructionCompiler;
 
 import java.util.Arrays;
@@ -22,7 +22,7 @@ public class EARJit {
 
     public void run(String earCode) {
         List<Instruction> instructions = Arrays.asList(earCode.split("(\\r?\\n)+")).stream()
-                .map(InstructionParser::parseLine)
+                .map(CommandParser::parseLine)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/ear-jit/src/test/java/EarJitCodeConverter.java
+++ b/ear-jit/src/test/java/EarJitCodeConverter.java
@@ -20,8 +20,9 @@ public class EarJitCodeConverter implements CodeConverter {
 
     @Override
     public MusicSource apply(String code) {
+        CommandParser parser = CommandParser.defaultCommandParser();
         List<Instruction> instructions = Arrays.asList(code.split("(\\r?\\n)+")).stream()
-                .map(CommandParser::parseCommand)
+                .map(parser::parseCommand)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/ear-jit/src/test/java/EarJitCodeConverter.java
+++ b/ear-jit/src/test/java/EarJitCodeConverter.java
@@ -2,7 +2,7 @@ import eflang.core.MusicSource;
 import eflang.ear.composer.Composer;
 import eflang.ear.core.Command;
 import eflang.ear.core.Instruction;
-import eflang.ear.core.InstructionParser;
+import eflang.ear.core.CommandParser;
 import eflang.ear.core.StatefulInstructionCompiler;
 import eflang.ear.jit.EARInstructionMusicSource;
 import eflang.hammer.CodeConverter;
@@ -21,7 +21,7 @@ public class EarJitCodeConverter implements CodeConverter {
     @Override
     public MusicSource apply(String code) {
         List<Instruction> instructions = Arrays.asList(code.split("(\\r?\\n)+")).stream()
-                .map(InstructionParser::parseLine)
+                .map(CommandParser::parseLine)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/ear-jit/src/test/java/EarJitCodeConverter.java
+++ b/ear-jit/src/test/java/EarJitCodeConverter.java
@@ -21,7 +21,7 @@ public class EarJitCodeConverter implements CodeConverter {
     @Override
     public MusicSource apply(String code) {
         List<Instruction> instructions = Arrays.asList(code.split("(\\r?\\n)+")).stream()
-                .map(CommandParser::parseLine)
+                .map(CommandParser::parseCommand)
                 .map(Command::compile)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());

--- a/hammer/src/main/java/eflang/hammer/EarCodeConverter.java
+++ b/hammer/src/main/java/eflang/hammer/EarCodeConverter.java
@@ -29,7 +29,7 @@ public class EarCodeConverter implements CodeConverter {
         try {
             return new StringMusicSource(compiler.compile(code));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to compile EAR code with error:\n" + e.getMessage());
+            throw new RuntimeException("Failed to compile EAR code with error", e);
         }
     }
 }


### PR DESCRIPTION
We lost this functionality when moving away from Regex based parsing.

This re-adds parse-time checks on argument types and numbers.